### PR TITLE
Problem: ledger is falsely detecting duplicate posts

### DIFF
--- a/doc/hydra.doc
+++ b/doc/hydra.doc
@@ -15,12 +15,72 @@ calling hydra_new ().
 
 This is the class interface:
 
-Please add @interface section in ../src/hydra.c.
+    //  Constructor, creates a new Hydra node. Note that until you start the
+    //  node it is silent and invisible to other nodes on the network. You may
+    //  specify the working directory, which defaults to .hydra in the current
+    //  working directory. Creates the working directory if necessary.
+    HYDRA_EXPORT hydra_t *
+        hydra_new (const char *directory);
+    
+    //  Destructor, destroys a Hydra node. When you destroy a node, any posts
+    //  it is sending or receiving will be discarded.
+    HYDRA_EXPORT void
+        hydra_destroy (hydra_t **self_p);
+    
+    //  Set node nickname; this is saved persistently in the Hydra configuration
+    //  file.
+    HYDRA_EXPORT void
+        hydra_set_nickname (hydra_t *self, const char *nickname);
+    
+    //  Return our node nickname, as previously stored in hydra.cfg, or set by
+    //  the hydra_set_nickname() method. Caller must free returned string using
+    //  zstr_free ().
+    HYDRA_EXPORT const char *
+        hydra_nickname (hydra_t *self);
+    
+    //  Set the trace level to animation of main actors; this is helpful to
+    //  debug the Hydra protocol flow.
+    HYDRA_EXPORT void
+        hydra_set_animate (hydra_t *self);
+    
+    //  Set the trace level to animation of all actors including those used in
+    //  security and discovery. Use this to collect diagnostic logs.
+    HYDRA_EXPORT void
+        hydra_set_verbose (hydra_t *self);
+    
+    //  By default, Hydra needs a network interface capable of broadcast UDP
+    //  traffic, e.g. WiFi or LAN interface. To run nodes on a stand-alone PC,
+    //  set the local IPC option. The node will then do gossip discovery over
+    //  IPC. Gossip discovery needs at exactly one node to be running in a
+    //  directory called ".hydra".
+    HYDRA_EXPORT void
+        hydra_set_local_ipc (hydra_t *self);
+    
+    //  Start node. When you start a node it begins discovery and post exchange.
+    //  Returns 0 if OK, -1 if it wasn't possible to start the node.
+    HYDRA_EXPORT int
+        hydra_start (hydra_t *self);
+    
+    //  Return next available post, if any. Does not block. If there are no posts
+    //  waiting, returns NULL. The caller can read the post using the hydra_post
+    //  API, and must destroy the post when done with it.
+    HYDRA_EXPORT hydra_post_t *
+        hydra_fetch (hydra_t *self);
+    
+    //  Return the Hydra version for run-time API detection
+    HYDRA_EXPORT void
+        hydra_version (int *major, int *minor, int *patch);
+    
+    //  Self test of this class
+    HYDRA_EXPORT void
+        hydra_test (bool verbose);
 
 This is the class self test code:
 
     //  Simple create/destroy test
     hydra_t *self = hydra_new (NULL);
     assert (self);
+    hydra_post_t *post = hydra_fetch (self);
+    assert (post == NULL);
     hydra_destroy (&self);
 

--- a/doc/hydra.txt
+++ b/doc/hydra.txt
@@ -8,7 +8,65 @@ hydra - main Hydra API
 SYNOPSIS
 --------
 ----
-Please add @interface section in ../src/hydra.c.
+//  Constructor, creates a new Hydra node. Note that until you start the
+//  node it is silent and invisible to other nodes on the network. You may
+//  specify the working directory, which defaults to .hydra in the current
+//  working directory. Creates the working directory if necessary.
+HYDRA_EXPORT hydra_t *
+    hydra_new (const char *directory);
+
+//  Destructor, destroys a Hydra node. When you destroy a node, any posts
+//  it is sending or receiving will be discarded.
+HYDRA_EXPORT void
+    hydra_destroy (hydra_t **self_p);
+
+//  Set node nickname; this is saved persistently in the Hydra configuration
+//  file.
+HYDRA_EXPORT void
+    hydra_set_nickname (hydra_t *self, const char *nickname);
+
+//  Return our node nickname, as previously stored in hydra.cfg, or set by
+//  the hydra_set_nickname() method. Caller must free returned string using
+//  zstr_free ().
+HYDRA_EXPORT const char *
+    hydra_nickname (hydra_t *self);
+
+//  Set the trace level to animation of main actors; this is helpful to
+//  debug the Hydra protocol flow.
+HYDRA_EXPORT void
+    hydra_set_animate (hydra_t *self);
+
+//  Set the trace level to animation of all actors including those used in
+//  security and discovery. Use this to collect diagnostic logs.
+HYDRA_EXPORT void
+    hydra_set_verbose (hydra_t *self);
+
+//  By default, Hydra needs a network interface capable of broadcast UDP
+//  traffic, e.g. WiFi or LAN interface. To run nodes on a stand-alone PC,
+//  set the local IPC option. The node will then do gossip discovery over
+//  IPC. Gossip discovery needs at exactly one node to be running in a
+//  directory called ".hydra".
+HYDRA_EXPORT void
+    hydra_set_local_ipc (hydra_t *self);
+
+//  Start node. When you start a node it begins discovery and post exchange.
+//  Returns 0 if OK, -1 if it wasn't possible to start the node.
+HYDRA_EXPORT int
+    hydra_start (hydra_t *self);
+
+//  Return next available post, if any. Does not block. If there are no posts
+//  waiting, returns NULL. The caller can read the post using the hydra_post
+//  API, and must destroy the post when done with it.
+HYDRA_EXPORT hydra_post_t *
+    hydra_fetch (hydra_t *self);
+
+//  Return the Hydra version for run-time API detection
+HYDRA_EXPORT void
+    hydra_version (int *major, int *minor, int *patch);
+
+//  Self test of this class
+HYDRA_EXPORT void
+    hydra_test (bool verbose);
 ----
 
 DESCRIPTION
@@ -34,5 +92,7 @@ EXAMPLE
 //  Simple create/destroy test
 hydra_t *self = hydra_new (NULL);
 assert (self);
+hydra_post_t *post = hydra_fetch (self);
+assert (post == NULL);
 hydra_destroy (&self);
 ----

--- a/doc/hydra_post.doc
+++ b/doc/hydra_post.doc
@@ -2,22 +2,113 @@
 
 Work with a Hydra post in memory.
 
-Please add @discuss section in ../src/hydra_post.c.
+TODO
+- add sender_id property indicating which peer, if any, sent us the post
 
 This is the class interface:
 
-    //  Create a new hydra_post
+    //  Create a new post
     HYDRA_EXPORT hydra_post_t *
-        hydra_post_new (void);
-    
-    //  Destroy the hydra_post
+        hydra_post_new (char *subject);
+        
+    //  Destroy the post
     HYDRA_EXPORT void
         hydra_post_destroy (hydra_post_t **self_p);
+        
+    //  Recalculate the post ID based on subject, timestamp, parent id, MIME
+    //  type, and content digest, and return post ID to caller.
+    HYDRA_EXPORT const char *
+        hydra_post_ident (hydra_post_t *self);
+        
+    //  Return the post subject, if set
+    HYDRA_EXPORT const char *
+        hydra_post_subject (hydra_post_t *self);
+        
+    //  Return the post timestamp
+    HYDRA_EXPORT const char *
+        hydra_post_timestamp (hydra_post_t *self);
+        
+    //  Return the post parent id, or empty string if not set
+    HYDRA_EXPORT const char *
+        hydra_post_parent_id (hydra_post_t *self);
+        
+    //  Return the post MIME type, if set
+    HYDRA_EXPORT const char *
+        hydra_post_mime_type (hydra_post_t *self);
+        
+    //  Return the post content digest
+    HYDRA_EXPORT const char *
+        hydra_post_digest (hydra_post_t *self);
     
-    //  Print properties of object
+    //  Return the post content location
+    HYDRA_EXPORT const char *
+        hydra_post_location (hydra_post_t *self);
+        
+    //  Return the post content size
+    HYDRA_EXPORT size_t
+        hydra_post_content_size (hydra_post_t *self);
+        
+    //  Set the post parent id, which must be a valid post ID
+    HYDRA_EXPORT void
+        hydra_post_set_parent_id (hydra_post_t *self, const char *parent_id);
+        
+    //  Set the post MIME type
+    HYDRA_EXPORT void
+        hydra_post_set_mime_type (hydra_post_t *self, const char *mime_type);
+        
+    //  Set the post content to a text string. Recalculates the post digest from
+    //  from the new content value. Sets the MIME type to text/plain.
+    HYDRA_EXPORT void
+        hydra_post_set_content (hydra_post_t *self, const char *content);
+        
+    //  Set the post content to a chunk of data. Recalculates the post digest
+    //  from the chunk contents. Takes ownership of the chunk. The data is not
+    //  stored on disk until you call hydra_post_save.
+    HYDRA_EXPORT void
+        hydra_post_set_data (hydra_post_t *self, const void *data, size_t size);
+        
+    //  Set the post content to point to a specified file. The file must exist.
+    //  Recalculates the post digest from the file contents. Returns 0 if OK, -1
+    //  if the file was unreadable.
+    HYDRA_EXPORT int
+        hydra_post_set_file (hydra_post_t *self, const char *location);
+        
+    //  Save the post to disk under the specified filename. Returns 0 if OK, -1
+    //  if the file could not be created. Posts are always stored in the "posts"
+    //  subdirectory of the current working directory.
+    HYDRA_EXPORT int
+        hydra_post_save (hydra_post_t *self, const char *filename);
+    
+    //  Load post from the specified filename. Posts are always read from the
+    //  "posts" subdirectory of the current working directory. Returns a new post
+    //  instance if the file could be loaded, else returns null.
+    HYDRA_EXPORT hydra_post_t *
+        hydra_post_load (const char *filename);
+        
+    //  Fetch a chunk of content for the post. The caller specifies the size and
+    //  offset of the chunk. A size of 0 means all content, which will fail if
+    //  there is insufficient memory available. The caller must destroy the chunk
+    //  when finished with it.
+    HYDRA_EXPORT zchunk_t *
+        hydra_post_fetch (hydra_post_t *self, size_t size, size_t offset);
+        
+    //  Encode a post metadata to a hydra_proto message
+    HYDRA_EXPORT void
+        hydra_post_encode (hydra_post_t *self, hydra_proto_t *proto);
+    
+    //  Create a new post from a hydra_proto HEADER-OK message.
+    HYDRA_EXPORT hydra_post_t *
+        hydra_post_decode (hydra_proto_t *proto);
+    
+    //  Duplicate a post instance. Does not create a new post on disk; this
+    //  provides a second instance of the same post item.
+    HYDRA_EXPORT hydra_post_t *
+        hydra_post_dup (hydra_post_t *self);
+    
+    //  Print the post file to stdout
     HYDRA_EXPORT void
         hydra_post_print (hydra_post_t *self);
-    
+        
     //  Self test of this class
     HYDRA_EXPORT int
         hydra_post_test (bool verbose);
@@ -25,7 +116,36 @@ This is the class interface:
 This is the class self test code:
 
     //  Simple create/destroy test
-    hydra_post_t *self = hydra_post_new ("Test post");
-    assert (self);
-    hydra_post_destroy (&self);
+    zsys_dir_create (".hydra_test");
+    zsys_dir_change (".hydra_test");
+        
+    hydra_post_t *post = hydra_post_new ("Test post");
+    assert (post);
+    hydra_post_set_content (post, "Hello, World");
+    assert (streq (hydra_post_mime_type (post), "text/plain"));
+    int rc = hydra_post_save (post, "testpost");
+    assert (rc == 0);
+    hydra_post_destroy (&post);
+    
+    post = hydra_post_load ("testpost");
+    assert (post);
+    assert (hydra_post_content_size (post) == 12);
+    if (verbose)
+        hydra_post_print (post);
+    zchunk_t *chunk = hydra_post_fetch (
+        post, hydra_post_content_size (post), 0);
+    assert (chunk);
+    assert (zchunk_size (chunk) == 12);
+    zchunk_destroy (&chunk);
+    
+    hydra_post_t *copy = hydra_post_dup (post);
+    assert (streq (hydra_post_ident (copy), hydra_post_ident (post)));
+    hydra_post_destroy (&post);
+    
+    //  Delete the test directory
+    zsys_dir_change ("..");
+    zdir_t *dir = zdir_new (".hydra_test", NULL);
+    assert (dir);
+    zdir_remove (dir, true);
+    zdir_destroy (&dir);
 

--- a/doc/hydra_post.txt
+++ b/doc/hydra_post.txt
@@ -8,18 +8,108 @@ hydra_post - work with a single Hydra post
 SYNOPSIS
 --------
 ----
-//  Create a new hydra_post
+//  Create a new post
 HYDRA_EXPORT hydra_post_t *
-    hydra_post_new (void);
-
-//  Destroy the hydra_post
+    hydra_post_new (char *subject);
+    
+//  Destroy the post
 HYDRA_EXPORT void
     hydra_post_destroy (hydra_post_t **self_p);
+    
+//  Recalculate the post ID based on subject, timestamp, parent id, MIME
+//  type, and content digest, and return post ID to caller.
+HYDRA_EXPORT const char *
+    hydra_post_ident (hydra_post_t *self);
+    
+//  Return the post subject, if set
+HYDRA_EXPORT const char *
+    hydra_post_subject (hydra_post_t *self);
+    
+//  Return the post timestamp
+HYDRA_EXPORT const char *
+    hydra_post_timestamp (hydra_post_t *self);
+    
+//  Return the post parent id, or empty string if not set
+HYDRA_EXPORT const char *
+    hydra_post_parent_id (hydra_post_t *self);
+    
+//  Return the post MIME type, if set
+HYDRA_EXPORT const char *
+    hydra_post_mime_type (hydra_post_t *self);
+    
+//  Return the post content digest
+HYDRA_EXPORT const char *
+    hydra_post_digest (hydra_post_t *self);
 
-//  Print properties of object
+//  Return the post content location
+HYDRA_EXPORT const char *
+    hydra_post_location (hydra_post_t *self);
+    
+//  Return the post content size
+HYDRA_EXPORT size_t
+    hydra_post_content_size (hydra_post_t *self);
+    
+//  Set the post parent id, which must be a valid post ID
+HYDRA_EXPORT void
+    hydra_post_set_parent_id (hydra_post_t *self, const char *parent_id);
+    
+//  Set the post MIME type
+HYDRA_EXPORT void
+    hydra_post_set_mime_type (hydra_post_t *self, const char *mime_type);
+    
+//  Set the post content to a text string. Recalculates the post digest from
+//  from the new content value. Sets the MIME type to text/plain.
+HYDRA_EXPORT void
+    hydra_post_set_content (hydra_post_t *self, const char *content);
+    
+//  Set the post content to a chunk of data. Recalculates the post digest
+//  from the chunk contents. Takes ownership of the chunk. The data is not
+//  stored on disk until you call hydra_post_save.
+HYDRA_EXPORT void
+    hydra_post_set_data (hydra_post_t *self, const void *data, size_t size);
+    
+//  Set the post content to point to a specified file. The file must exist.
+//  Recalculates the post digest from the file contents. Returns 0 if OK, -1
+//  if the file was unreadable.
+HYDRA_EXPORT int
+    hydra_post_set_file (hydra_post_t *self, const char *location);
+    
+//  Save the post to disk under the specified filename. Returns 0 if OK, -1
+//  if the file could not be created. Posts are always stored in the "posts"
+//  subdirectory of the current working directory.
+HYDRA_EXPORT int
+    hydra_post_save (hydra_post_t *self, const char *filename);
+
+//  Load post from the specified filename. Posts are always read from the
+//  "posts" subdirectory of the current working directory. Returns a new post
+//  instance if the file could be loaded, else returns null.
+HYDRA_EXPORT hydra_post_t *
+    hydra_post_load (const char *filename);
+    
+//  Fetch a chunk of content for the post. The caller specifies the size and
+//  offset of the chunk. A size of 0 means all content, which will fail if
+//  there is insufficient memory available. The caller must destroy the chunk
+//  when finished with it.
+HYDRA_EXPORT zchunk_t *
+    hydra_post_fetch (hydra_post_t *self, size_t size, size_t offset);
+    
+//  Encode a post metadata to a hydra_proto message
+HYDRA_EXPORT void
+    hydra_post_encode (hydra_post_t *self, hydra_proto_t *proto);
+
+//  Create a new post from a hydra_proto HEADER-OK message.
+HYDRA_EXPORT hydra_post_t *
+    hydra_post_decode (hydra_proto_t *proto);
+
+//  Duplicate a post instance. Does not create a new post on disk; this
+//  provides a second instance of the same post item.
+HYDRA_EXPORT hydra_post_t *
+    hydra_post_dup (hydra_post_t *self);
+
+//  Print the post file to stdout
 HYDRA_EXPORT void
     hydra_post_print (hydra_post_t *self);
-
+    
 //  Self test of this class
 HYDRA_EXPORT int
     hydra_post_test (bool verbose);
@@ -30,14 +120,44 @@ DESCRIPTION
 
 Work with a Hydra post in memory.
 
-Please add @discuss section in ../src/hydra_post.c.
+TODO
+- add sender_id property indicating which peer, if any, sent us the post
 
 EXAMPLE
 -------
 .From hydra_post_test method
 ----
 //  Simple create/destroy test
-hydra_post_t *self = hydra_post_new ("Test post");
-assert (self);
-hydra_post_destroy (&self);
+zsys_dir_create (".hydra_test");
+zsys_dir_change (".hydra_test");
+    
+hydra_post_t *post = hydra_post_new ("Test post");
+assert (post);
+hydra_post_set_content (post, "Hello, World");
+assert (streq (hydra_post_mime_type (post), "text/plain"));
+int rc = hydra_post_save (post, "testpost");
+assert (rc == 0);
+hydra_post_destroy (&post);
+
+post = hydra_post_load ("testpost");
+assert (post);
+assert (hydra_post_content_size (post) == 12);
+if (verbose)
+    hydra_post_print (post);
+zchunk_t *chunk = hydra_post_fetch (
+    post, hydra_post_content_size (post), 0);
+assert (chunk);
+assert (zchunk_size (chunk) == 12);
+zchunk_destroy (&chunk);
+
+hydra_post_t *copy = hydra_post_dup (post);
+assert (streq (hydra_post_ident (copy), hydra_post_ident (post)));
+hydra_post_destroy (&post);
+
+//  Delete the test directory
+zsys_dir_change ("..");
+zdir_t *dir = zdir_new (".hydra_test", NULL);
+assert (dir);
+zdir_remove (dir, true);
+zdir_destroy (&dir);
 ----

--- a/src/hydra_ledger.c
+++ b/src/hydra_ledger.c
@@ -36,6 +36,7 @@ s_have_new_post (hydra_ledger_t *self, hydra_post_t *post, char *filename)
     //  If the post is new then we store it, otherwise we get rid of it
     if (zhash_insert (self->post_files, hydra_post_ident (post), filename) == 0) {
         //  Store post ID in posts_list and bump size
+        zsys_warning ("hydra_ledger: store post, ident=%s", hydra_post_ident (post));
         if (self->size == self->max_size - 1) {
             self->max_size *= 2;
             self->posts_list = (char **) realloc (

--- a/src/hydra_post.c
+++ b/src/hydra_post.c
@@ -416,9 +416,10 @@ hydra_post_dup (hydra_post_t *self)
     hydra_post_t *copy = hydra_post_new (self->subject);
     if (copy) {
         strcpy (copy->ident, self->ident);
-        strcpy (self->timestamp, self->timestamp);
+        strcpy (copy->timestamp, self->timestamp);
         strcpy (copy->parent_id, self->parent_id);
         copy->mime_type = strdup (self->mime_type);
+        copy->location = strdup (self->location);
         strcpy (copy->digest, self->digest);
         copy->content_size = self->content_size;
     }

--- a/src/hydra_server.c
+++ b/src/hydra_server.c
@@ -187,6 +187,10 @@ s_server_handle_sink (zloop_t *loop, zsock_t *reader, void *argument)
     server_t *self = (server_t *) argument;
     hydra_post_t *post;
     zsock_recv (reader, "p", &post);
+
+    puts ("---- received  ----");
+    hydra_post_print (post);
+    
     hydra_ledger_store (self->ledger, &post);
     return 0;
 }


### PR DESCRIPTION
Solution: hydra_post_dup was not copying all properties correctly.
Fixed.