### PR TITLE
Problem: Travis CI doesn't run C build, just clojure, which fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
-language: clojure
-lein: lein2
-script: lein2 test :all
-jdk:
-  - openjdk7
-  - openjdk6
+# Travis CI script
+
+language: c
+
+env:
+- BUILD_TYPE=default
+- BUILD_TYPE=qt-android
+
+# Build and check this project according to the BUILD_TYPE
+script: ./ci_build.sh

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+if [ $BUILD_TYPE == "default" ]; then
+    #   libsodium
+    git clone git://github.com/jedisct1/libsodium.git
+    ( cd libsodium && ./autogen.sh && ./configure && make check && sudo make install && sudo ldconfig )
+
+    #   libzmq
+    git clone git://github.com/zeromq/libzmq.git
+    ( cd libzmq && ./autogen.sh && ./configure && make check && sudo make install && sudo ldconfig )
+
+    #   czmq
+    git clone git://github.com/zeromq/czmq.git
+    ( cd czmq && ./autogen.sh && ./configure && make check && sudo make install && sudo ldconfig )
+
+    #   zyre
+    git clone git://github.com/zeromq/zyre.git
+    ( cd czmq && ./autogen.sh && ./configure && make check && sudo make install && sudo ldconfig )
+
+    #   Build and check this project
+    ./autogen.sh && ./configure && make && make check && sudo make install
+else
+    cd ./builds/${BUILD_TYPE} && ./ci_build.sh
+fi


### PR DESCRIPTION
Solution: Travis CI doesn't inherently support multi-language builds,
so we hack around it using the `ci_build.sh` script and the `BUILD_TYPE`
environment variable. When someone who knows about clojure fixes the
build, they can reinstate it on CI by adding the necessary procedure
to set up and run the tests to `ci_build.sh` script or to the `builds`
directory, where the `ci_build.sh` script looks by default. For now,
we need CI most for the builds that are working, and I don't know
enough about clojure to set up the environment for that build myself.