### PR TITLE
Problem: No way to get text/plain content as a string.

### DIFF
--- a/api/hydra_post.xml
+++ b/api/hydra_post.xml
@@ -52,6 +52,12 @@
         <return type = "integer" c_type = "size_t" />
     </method>
     
+    <method name = "content">
+        Return the post content as a string. Returns NULL if the MIME type is
+        not "text/plain". The caller must destroy the string when finished with it.
+        <return type = "string" fresh = "1" />
+    </method>
+    
     <method name = "set_parent_id">
         Set the post parent id, which must be a valid post ID
         <argument name = "parent_id" type = "string" />

--- a/bindings/qml/src/QmlHydraPost.cpp
+++ b/bindings/qml/src/QmlHydraPost.cpp
@@ -58,6 +58,16 @@ size_t QmlHydraPost::contentSize () {
 };
 
 ///
+//  Return the post content as a string. Returns NULL if the MIME type is      
+//  not "text/plain". The caller must destroy the string when finished with it.
+QString QmlHydraPost::content () {
+    char *retStr_ = hydra_post_content (self);
+    QString retQStr_ = QString (retStr_);
+    free (retStr_);
+    return retQStr_;
+};
+
+///
 //  Set the post parent id, which must be a valid post ID
 void QmlHydraPost::setParentId (const QString &parentId) {
     hydra_post_set_parent_id (self, parentId.toUtf8().data());

--- a/bindings/qml/src/QmlHydraPost.h
+++ b/bindings/qml/src/QmlHydraPost.h
@@ -51,6 +51,10 @@ public slots:
     //  Return the post content size
     size_t contentSize ();
 
+    //  Return the post content as a string. Returns NULL if the MIME type is      
+    //  not "text/plain". The caller must destroy the string when finished with it.
+    QString content ();
+
     //  Set the post parent id, which must be a valid post ID
     void setParentId (const QString &parentId);
 

--- a/bindings/ruby/lib/hydra/ffi.rb
+++ b/bindings/ruby/lib/hydra/ffi.rb
@@ -58,6 +58,7 @@ module Hydra
       attach_function :hydra_post_digest, [:pointer], :string, **opts
       attach_function :hydra_post_location, [:pointer], :string, **opts
       attach_function :hydra_post_content_size, [:pointer], :pointer, **opts
+      attach_function :hydra_post_content, [:pointer], :pointer, **opts
       attach_function :hydra_post_set_parent_id, [:pointer, :string], :void, **opts
       attach_function :hydra_post_set_mime_type, [:pointer, :string], :void, **opts
       attach_function :hydra_post_set_content, [:pointer, :string], :void, **opts

--- a/bindings/ruby/lib/hydra/ffi/post.rb
+++ b/bindings/ruby/lib/hydra/ffi/post.rb
@@ -117,6 +117,14 @@ module Hydra
         result
       end
       
+      # Return the post content as a string. Returns NULL if the MIME type is      
+      # not "text/plain". The caller must destroy the string when finished with it.
+      def content
+        raise DestroyedError unless @ptr
+        result = ::Hydra::FFI.hydra_post_content @ptr
+        result
+      end
+      
       # Set the post parent id, which must be a valid post ID
       def set_parent_id parent_id
         raise DestroyedError unless @ptr

--- a/include/hydra_post.h
+++ b/include/hydra_post.h
@@ -61,6 +61,11 @@ HYDRA_EXPORT const char *
 HYDRA_EXPORT size_t
     hydra_post_content_size (hydra_post_t *self);
 
+//  Return the post content as a string. Returns NULL if the MIME type is      
+//  not "text/plain". The caller must destroy the string when finished with it.
+HYDRA_EXPORT char *
+    hydra_post_content (hydra_post_t *self);
+
 //  Set the post parent id, which must be a valid post ID
 HYDRA_EXPORT void
     hydra_post_set_parent_id (hydra_post_t *self, const char *parent_id);

--- a/src/hydra.c
+++ b/src/hydra.c
@@ -247,6 +247,7 @@ s_self_destroy (self_t **self_p)
         self_t *self = *self_p;
         zpoller_destroy (&self->poller);
         zactor_destroy (&self->server);
+        zhashx_destroy (&self->peers);
         zlistx_destroy (&self->posts);
         zyre_destroy (&self->zyre);
         zstr_free (&self->reason);

--- a/src/hydra_post.c
+++ b/src/hydra_post.c
@@ -177,6 +177,22 @@ hydra_post_content_size (hydra_post_t *self)
 
 
 //  --------------------------------------------------------------------------
+//  Return the post content as a string. Returns NULL if the MIME type is
+//  not "text/plain". The caller must destroy the string when finished with it.
+
+char *
+hydra_post_content (hydra_post_t *self)
+{
+    assert (self);
+    char *content = NULL;
+    if (self->content && self->mime_type
+    &&  streq (self->mime_type, "text/plain"))
+        content = zchunk_strdup (self->content);
+    return content;
+}
+
+
+//  --------------------------------------------------------------------------
 //  Set the post parent id, which must be a valid post ID
 
 void
@@ -464,6 +480,9 @@ hydra_post_test (bool verbose)
     assert (post);
     hydra_post_set_content (post, "Hello, World");
     assert (streq (hydra_post_mime_type (post), "text/plain"));
+    char *content = hydra_post_content (post);
+    assert (streq (content, "Hello, World"));
+    zstr_free (&content);
     int rc = hydra_post_save (post, "testpost");
     assert (rc == 0);
     hydra_post_destroy (&post);


### PR DESCRIPTION
Solution: Add the hydra_post_content method, which returns it as a freshly allocated string.