### PR TITLE
Problem: server had half-finished credit mechanism

### DIFF
--- a/main/clojure/src/org/zproto/hydra_server.clj
+++ b/main/clojure/src/org/zproto/hydra_server.clj
@@ -33,7 +33,6 @@
 (defprotocol HydraServerBackend
   (set-server-identity [this msg])
   (signal-command-invalid [this msg])
-  (check-if-client-has-credit [this msg])
   (fetch-next-older-post [this msg])
   (fetch-next-newer-post [this msg])
   (fetch-post-metadata [this msg])
@@ -78,8 +77,8 @@
     HydraProto/EXCEPTION [ (send HydraProto/ERROR) terminate ]
   }
   :connected {
-    HydraProto/NEXT_OLDER [ (action check-if-client-has-credit) (action fetch-next-older-post) (send HydraProto/NEXT_OK) ]
-    HydraProto/NEXT_NEWER [ (action check-if-client-has-credit) (action fetch-next-newer-post) (send HydraProto/NEXT_OK) ]
+    HydraProto/NEXT_OLDER [ (action fetch-next-older-post) (send HydraProto/NEXT_OK) ]
+    HydraProto/NEXT_NEWER [ (action fetch-next-newer-post) (send HydraProto/NEXT_OK) ]
     HydraProto/NO_SUCH_POST [ (send HydraProto/NEXT_EMPTY) ]
     HydraProto/META [ (action fetch-post-metadata) (send HydraProto/META_OK) ]
     HydraProto/CHUNK [ (action fetch-post-content-chunk) (send HydraProto/CHUNK_OK) ]

--- a/src/hydra_server.c
+++ b/src/hydra_server.c
@@ -56,7 +56,6 @@ struct _client_t {
     hydra_proto_t *message;     //  Message from and to client
     hydra_ledger_t *ledger;     //  Posts ledger, same as server ledger
     hydra_post_t *post;         //  Current post we're sending
-    size_t credit;              //  How many posts we'll send one client
 };
 
 //  Include the generated server engine
@@ -203,7 +202,6 @@ static int
 client_initialize (client_t *self)
 {
     self->ledger = self->server->ledger;
-    self->credit = 20;
     return 0;
 }
 
@@ -228,20 +226,6 @@ set_server_identity (client_t *self)
     assert (identity);
     hydra_proto_set_identity (self->message, identity);
     hydra_proto_set_nickname (self->message, nickname);
-}
-
-
-//  ---------------------------------------------------------------------------
-//  check_if_client_has_credit
-//
-
-static void
-check_if_client_has_credit (client_t *self)
-{
-    if (--self->credit == 0) {
-        hydra_proto_set_status (self->message, HYDRA_PROTO_ACCESS_REFUSED);
-        engine_set_exception (self, exception_event);
-    }
 }
 
 

--- a/src/hydra_server.xml
+++ b/src/hydra_server.xml
@@ -23,12 +23,10 @@
 
     <state name = "connected" inherit = "defaults">
         <event name = "NEXT OLDER">
-            <action name = "check if client has credit" />
             <action name = "fetch next older post" />
             <action name = "send" message = "NEXT OK" />
         </event>
         <event name = "NEXT NEWER">
-            <action name = "check if client has credit" />
             <action name = "fetch next newer post" />
             <action name = "send" message = "NEXT OK" />
         </event>

--- a/src/hydra_server_engine.inc
+++ b/src/hydra_server_engine.inc
@@ -132,8 +132,6 @@ static void
 static void
     signal_command_invalid (client_t *self);
 static void
-    check_if_client_has_credit (client_t *self);
-static void
     fetch_next_older_post (client_t *self);
 static void
     fetch_next_newer_post (client_t *self);
@@ -497,12 +495,6 @@ s_client_execute (s_client_t *self, event_t event)
             case connected_state:
                 if (self->event == next_older_event) {
                     if (!self->exception) {
-                        //  check if client has credit
-                        if (self->server->verbose)
-                            zsys_debug ("%s:         $ check if client has credit", self->log_prefix);
-                        check_if_client_has_credit (&self->client);
-                    }
-                    if (!self->exception) {
                         //  fetch next older post
                         if (self->server->verbose)
                             zsys_debug ("%s:         $ fetch next older post", self->log_prefix);
@@ -520,12 +512,6 @@ s_client_execute (s_client_t *self, event_t event)
                 }
                 else
                 if (self->event == next_newer_event) {
-                    if (!self->exception) {
-                        //  check if client has credit
-                        if (self->server->verbose)
-                            zsys_debug ("%s:         $ check if client has credit", self->log_prefix);
-                        check_if_client_has_credit (&self->client);
-                    }
                     if (!self->exception) {
                         //  fetch next newer post
                         if (self->server->verbose)


### PR DESCRIPTION
This was an abortive design to manage the flow of posts to specific
clients. However it was not solving a clear problem so I'd removed
it from the protocol and client. Dangling code in the server caused
an ACCESS REFUSED error after fetching 20 posts.

Solution: remove the dangling code from the server.

Fixes #66